### PR TITLE
fix: katana-app maxResponseTime to 2500ms

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -7,7 +7,7 @@ sites:
     url: https://katana.network
   - name: katana app
     url: https://app.katana.network
-    maxResponseTime: 1000
+    maxResponseTime: 1500
   - name: katana api
     url: https://api.katana.network/health
     # "degraded" -> shown as degraded (yellow), not down.

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -7,7 +7,7 @@ sites:
     url: https://katana.network
   - name: katana app
     url: https://app.katana.network
-    maxResponseTime: 1500
+    maxResponseTime: 2500
   - name: katana api
     url: https://api.katana.network/health
     # "degraded" -> shown as degraded (yellow), not down.

--- a/history/balance-api.yml
+++ b/history/balance-api.yml
@@ -1,7 +1,7 @@
 url: https://balance-api-gcp.polygon.technology/health-check
 status: up
 code: 200
-responseTime: 254
-lastUpdated: 2026-09-01T23:02:36.343Z
+responseTime: 396
+lastUpdated: 2026-09-02T10:39:10.763Z
 startTime: 2025-11-17T12:45:59.210Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/coingecko-api.yml
+++ b/history/coingecko-api.yml
@@ -1,7 +1,7 @@
 url: https://api.coingecko.com/api/v3/ping
 status: up
 code: 200
-responseTime: 152
-lastUpdated: 2026-09-01T23:02:37.820Z
+responseTime: 36
+lastUpdated: 2026-09-02T10:39:11.849Z
 startTime: 2026-02-20T12:15:27.678Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/conduit-katana-rpc.yml
+++ b/history/conduit-katana-rpc.yml
@@ -1,7 +1,7 @@
 url: $CONDUIT_KATANA_ENDPOINT
 status: up
 code: 200
-responseTime: 221
-lastUpdated: 2026-09-01T23:02:39.617Z
+responseTime: 360
+lastUpdated: 2026-09-02T10:39:13.089Z
 startTime: 2026-02-20T12:15:34.207Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/configcat-cdn.yml
+++ b/history/configcat-cdn.yml
@@ -1,7 +1,7 @@
 url: https://cdn-global.configcat.com
 status: up
 code: 403
-responseTime: 119
-lastUpdated: 2026-09-01T23:02:38.915Z
+responseTime: 22
+lastUpdated: 2026-09-02T10:39:12.336Z
 startTime: 2026-02-20T12:15:30.150Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-api.yml
+++ b/history/katana-api.yml
@@ -1,7 +1,7 @@
 url: https://api.katana.network/health
 status: up
 code: 200
-responseTime: 249
-lastUpdated: 2026-09-01T23:02:34.893Z
+responseTime: 502
+lastUpdated: 2026-09-02T10:39:09.483Z
 startTime: 2025-09-19T18:40:02.273Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-app.yml
+++ b/history/katana-app.yml
@@ -1,7 +1,7 @@
 url: https://app.katana.network
-status: degraded
+status: up
 code: 200
-responseTime: 2202
-lastUpdated: 2026-09-02T10:33:59.208Z
+responseTime: 105
+lastUpdated: 2026-09-02T10:39:06.035Z
 startTime: 2025-09-19T18:39:59.539Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-questing-api.yml
+++ b/history/katana-questing-api.yml
@@ -1,7 +1,7 @@
 url: https://questing-api.katana.network/health
 status: up
 code: 200
-responseTime: 470
-lastUpdated: 2026-09-01T23:02:35.390Z
+responseTime: 314
+lastUpdated: 2026-09-02T10:39:09.824Z
 startTime: 2026-02-04T16:31:58.356Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-rpc-block-number.yml
+++ b/history/katana-rpc-block-number.yml
@@ -1,7 +1,7 @@
 url: https://rpc.katana.network
 status: up
 code: 200
-responseTime: 196
-lastUpdated: 2026-09-01T23:02:39.369Z
+responseTime: 154
+lastUpdated: 2026-09-02T10:39:12.700Z
 startTime: 2026-02-20T12:15:33.596Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-rpc-chain-id.yml
+++ b/history/katana-rpc-chain-id.yml
@@ -1,7 +1,7 @@
 url: https://rpc.katana.network
 status: up
 code: 200
-responseTime: 203
-lastUpdated: 2026-09-01T23:02:39.145Z
+responseTime: 155
+lastUpdated: 2026-09-02T10:39:12.518Z
 startTime: 2026-02-20T12:15:30.870Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katana-website.yml
+++ b/history/katana-website.yml
@@ -1,7 +1,7 @@
 url: https://katana.network
 status: up
 code: 200
-responseTime: 88
-lastUpdated: 2026-09-01T23:02:16.150Z
+responseTime: 282
+lastUpdated: 2026-09-02T10:39:05.897Z
 startTime: 2025-09-19T18:39:58.901Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/katanascan-explorer.yml
+++ b/history/katanascan-explorer.yml
@@ -1,7 +1,7 @@
 url: https://katanascan-liveness-probe.polygon-technology.workers.dev
 status: up
 code: 200
-responseTime: 329
-lastUpdated: 2026-09-01T23:02:39.973Z
+responseTime: 270
+lastUpdated: 2026-09-02T10:39:13.387Z
 startTime: 2026-02-20T12:15:36.982Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/merkl-api.yml
+++ b/history/merkl-api.yml
@@ -1,7 +1,7 @@
 url: https://api.merkl.xyz/v4/tokens/reward/747474
 status: up
 code: 200
-responseTime: 412
-lastUpdated: 2026-09-01T23:02:38.518Z
+responseTime: 280
+lastUpdated: 2026-09-02T10:39:12.154Z
 startTime: 2026-02-20T12:15:28.331Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/morpho-api.yml
+++ b/history/morpho-api.yml
@@ -1,7 +1,7 @@
 url: https://blue-api.morpho.org/graphql
 status: up
 code: 200
-responseTime: 635
-lastUpdated: 2026-09-01T23:02:37.391Z
+responseTime: 404
+lastUpdated: 2026-09-02T10:39:11.567Z
 startTime: 2026-02-20T12:15:22.656Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/public-rpc.yml
+++ b/history/public-rpc.yml
@@ -1,7 +1,7 @@
 url: https://rpc.katana.network
 status: up
 code: 200
-responseTime: 321
-lastUpdated: 2026-09-01T23:02:35.738Z
+responseTime: 278
+lastUpdated: 2026-09-02T10:39:10.132Z
 startTime: 2025-09-19T21:53:24.686Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/sushiswap-api.yml
+++ b/history/sushiswap-api.yml
@@ -1,7 +1,7 @@
 url: https://api.sushi.com/price/v1/747474
 status: up
 code: 200
-responseTime: 219
-lastUpdated: 2026-09-01T23:02:37.636Z
+responseTime: 192
+lastUpdated: 2026-09-02T10:39:11.786Z
 startTime: 2026-02-20T12:15:23.980Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/trails-sequence.yml
+++ b/history/trails-sequence.yml
@@ -1,7 +1,7 @@
 url: https://trails-api.sequence.app/rpc/Trails/GetIntent
 status: up
 code: 400
-responseTime: 226
-lastUpdated: 2026-09-01T23:02:38.771Z
+responseTime: 107
+lastUpdated: 2026-09-02T10:39:12.288Z
 startTime: 2026-02-20T12:15:29.513Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/yearn-api.yml
+++ b/history/yearn-api.yml
@@ -1,7 +1,7 @@
 url: https://kong.yearn.farm/api/gql
 status: up
 code: 200
-responseTime: 358
-lastUpdated: 2026-09-01T23:02:36.728Z
+responseTime: 344
+lastUpdated: 2026-09-02T10:39:11.134Z
 startTime: 2026-02-20T12:15:21.653Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/zerion.yml
+++ b/history/zerion.yml
@@ -1,7 +1,7 @@
 url: https://api.zerion.io/health
 status: up
 code: 200
-responseTime: 289
-lastUpdated: 2026-09-01T23:02:36.054Z
+responseTime: 181
+lastUpdated: 2026-09-02T10:39:10.340Z
 startTime: 2025-11-17T11:28:42.733Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
`maxResponseTime` for `app.katana.network` was 1000ms, which sits on the typical GitHub Actions load time (~1100ms). That caused Slack to flap all day on HTTP 200s.

Raised to `2500ms` so checks in the 1000–2500ms band no longer open incidents.